### PR TITLE
Install Seq2seq_upgrade as a python package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+
+.idea/*

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ from the regular tensorflow. Instead import:
 
 from Seq2Seq_Upgrade_Tensorflow. Otherwise class inheritance will be thrown off, and you will get an `isinstance` error!
 
+You can also try to install seq2seq_upgrade as a python package
+
+    sudo pip install git+ssh://github.com/LeavesBreathe/Seq2Seq_Upgrade_TensorFlow.git
+
+or a bit longer version in case the previous one didn't work
+
+    git clone git@github.com:LeavesBreathe/Seq2Seq_Upgrade_TensorFlow.git
+    cd Seq2Seq_Upgrade_TensorFlow
+    sudo python setup.py build & sudo python setup.py install
+    
+After that you hopefully be able to simply write `import seq2seq_upgrade`
 
 
 ##Different RNN Layers on Multiple GPU's -- Working

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup
+from setuptools import find_packages
+
+install_requires = [
+    'tensorflow==0.5.0'
+]
+
+setup(
+      name='Seq2seq_upgrade',
+      version='0.0.1',
+      description='Additional Sequence to Sequence Features for TensorFlow',
+      author='LeavesBreathe',
+      url='https://github.com/LeavesBreathe/Seq2Seq_Upgrade_TensorFlow',
+      license='Apache v2',
+      install_requires=install_requires,
+      packages=find_packages()
+)


### PR DESCRIPTION
Hi, Nick!
Integrating you lib into a project by adding lines

```python
sys.path.insert(0, os.environ['HOME']) #add the dir that you cloned to
from Seq2Seq_Upgrade_TensorFlow.seq2seq_upgrade import seq2seq_enhanced, rnn_cell_enhanced
```
maybe a handy solution, however it doesn't let IDE such as PyCharm to look into your lib's code, thus preventing it from giving useful comments and warnings. A better solution is to build your lib as python package, the included setup.py file is aimed to do this. See the changes in readme for the instructions.