### PR TITLE
Fix lib import statements

### DIFF
--- a/seq2seq_upgrade/rnn_cell_enhanced.py
+++ b/seq2seq_upgrade/rnn_cell_enhanced.py
@@ -15,8 +15,8 @@ import tensorflow as tf
 from tensorflow.models.rnn import linear
 
 
-from Seq2Seq_Upgrade_TensorFlow.seq2seq_upgrade import linear_functions_enhanced as lfe
-from Seq2Seq_Upgrade_TensorFlow.seq2seq_upgrade import unitary_linear
+from seq2seq_upgrade import linear_functions_enhanced as lfe
+from seq2seq_upgrade import unitary_linear
 
 
 # import unitary_rnn_library as url

--- a/seq2seq_upgrade/rnn_enhanced.py
+++ b/seq2seq_upgrade/rnn_enhanced.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import tensorflow as tf
 
 # from tensorflow.models.rnn import rnn_cell
-from Seq2Seq_Upgrade_TensorFlow.seq2seq_upgrade import rnn_cell_enhanced as rnn_cell
+from seq2seq_upgrade import rnn_cell_enhanced as rnn_cell
 
 from tensorflow.python.ops import control_flow_ops
 

--- a/seq2seq_upgrade/seq2seq_enhanced.py
+++ b/seq2seq_upgrade/seq2seq_enhanced.py
@@ -14,10 +14,10 @@ import tensorflow as tf
 from tensorflow.models.rnn import linear
 # from tensorflow.models.rnn import rnn
 # from tensorflow.models.rnn import rnn_cell
-from Seq2Seq_Upgrade_TensorFlow.seq2seq_upgrade import rnn_enhanced as rnn
-from Seq2Seq_Upgrade_TensorFlow.seq2seq_upgrade import rnn_cell_enhanced as rnn_cell
-from Seq2Seq_Upgrade_TensorFlow.seq2seq_upgrade import linear_functions_enhanced as lfe
-from Seq2Seq_Upgrade_TensorFlow.seq2seq_upgrade import decoding_enhanced
+from seq2seq_upgrade import rnn_enhanced as rnn
+from seq2seq_upgrade import rnn_cell_enhanced as rnn_cell
+from seq2seq_upgrade import linear_functions_enhanced as lfe
+from seq2seq_upgrade import decoding_enhanced
 
 
 import cf

--- a/seq2seq_upgrade/unitary_rnn_library.py
+++ b/seq2seq_upgrade/unitary_rnn_library.py
@@ -12,6 +12,7 @@ import random, sys, os
 
 import numpy as np
 from six.moves import xrange  # pylint: disable=redefined-builtin
+import theano
 import tensorflow as tf
 
 def initialize_matrix(n_in, n_out, name, rng):


### PR DESCRIPTION
Before:
```python
from Seq2Seq_Upgrade_TensorFlow.seq2seq_upgrade import rnn_enhanced as rnn
```

After:
```python
from seq2seq_upgrade import rnn_enhanced as rnn
```

This fix is needed in order to properly use your lib after running through `setup.py`.
However, after that your trick with lib import should be updated a bit:
```python
sys.path.insert(0, os.environ['HOME']) #add the path to Seq2Seq_Upgrade_TensorFlow/seq2seq_upgrade
from seq2seq_upgrade import seq2seq_enhanced, rnn_cell_enhanced
```

Please check that it works for you. I didn't check it myself because for some reason `sys.path.insert(0, PATH_TO_YOUR_LIB)` doesn't work for me straight away.
